### PR TITLE
fix paramvector timeseries cropping

### DIFF
--- a/02_helper_functions/ImportPX4LogData.m
+++ b/02_helper_functions/ImportPX4LogData.m
@@ -192,9 +192,10 @@ function [sysvector, topics, paramvector, params] = ...
 
                         % set field in parameter struct
                         temp_params = csv_numeric_data(idx_data:idx_data+1,:);
-                        temp_params = temp_params(~isnan(temp_params));
+                        temp_params1 = temp_params(1,~isnan(temp_params(1,:)));
+                        temp_params2 = temp_params(2,~isnan(temp_params(2,:))) * fconv_timestamp;
                         paramvector.(param_fields{idx_params}) = ...
-                            timeseries(temp_params(1,:), temp_params(2,:));
+                            timeseries(temp_params1', temp_params2');
 
                         % set logged
                         params.(param_fields{idx_params}).logged = true;


### PR DESCRIPTION
current param import was cropping off the data after time zero. this fixes that.

addresses #35 
addresses #34 

Apparently this is also a duplicate of #37 .... @acfloria, maybe just take your pick of which PR you like better? 